### PR TITLE
Fix Advanced Search

### DIFF
--- a/lec0/project/advanced_search.html
+++ b/lec0/project/advanced_search.html
@@ -13,6 +13,7 @@
     <main>
         <div class="adv-search">
             <p>Find pages with...</p>
+            <form action="https://www.google.com/search">
             <div class="row">
                 <span>
                     <label for="as_q" class="col-2 mb-2">all these words:</label>
@@ -37,11 +38,8 @@
                     <input id="as_noh" type="text" name="as_noh">
                 </span>
             </div>
-            <form action="https://www.google.com/search">
+	    <input type="submit" value="Advanced Search">
             </form>
-            <div class="col">
-                <input type="submit" value="Advanced Search">
-            </div>
         </main>
     </body>
 </html>


### PR DESCRIPTION
# Description

This PR introduces a fix for the advanced search page. 7ed1922f06e982bc300fb554c25f611bc0f21518 introduce a regression whereby the "search" button on the Advanced Search page was a no-op.

The fix require wrapping all input elements with a `<form>` tag that was configured to attach all URL query parameters to Google's search URL.